### PR TITLE
Updated AddBook,LenderListing and EditModal

### DIFF
--- a/src/components/AddBook.js
+++ b/src/components/AddBook.js
@@ -61,7 +61,7 @@ const AddBook = ({ addBookToLenderList }) => {
             <Form.Group controlId="imageUrl">
               <Form.Control
                 type="text"
-                placeholder="Image Url (required)"
+                placeholder="Image Url"
                 autoFocus
                 className="form-input"
                 onChange={(e) => setImgUrl(e.target.value)}
@@ -89,7 +89,7 @@ const AddBook = ({ addBookToLenderList }) => {
             <Form.Group controlId="page">
               <Form.Control
                 type="number"
-                placeholder="Page (required)"
+                placeholder="Page"
                 className="form-input"
                 onChange={(e) => setPage(e.target.value)}
                 value={page}
@@ -98,7 +98,7 @@ const AddBook = ({ addBookToLenderList }) => {
             <Form.Group controlId="releaseYear">
               <Form.Control
                 type="number"
-                placeholder="Release Year (required)"
+                placeholder="Release Year"
                 className="form-input"
                 onChange={(e) => setReleaseYear(e.target.value)}
                 value={releaseYear}

--- a/src/components/EditModal.js
+++ b/src/components/EditModal.js
@@ -55,7 +55,7 @@ const EditModal = ({ show, handleClose, bookData, handleEdit }) => {
                   <Col sm={9}>
                     <Form.Control
                       type="text"
-                      name="url"
+                      name="imgUrl"
                       defaultValue={bookData.book.imgUrl}
                       onChange={handleChange}
                     />

--- a/src/components/LenderListing.js
+++ b/src/components/LenderListing.js
@@ -55,7 +55,7 @@ const LenderListing = ({ books, handleEdit, handleListingDelete, error }) => {
                   <Col xs={4}>
                     <img
                       src={bookData.book.imgUrl}
-                      alt={bookData.book.title}
+                      alt={"No Image Provided for: " + bookData.book.title}
                       style={{
                         width: "80px",
                         height: "120px",
@@ -68,8 +68,8 @@ const LenderListing = ({ books, handleEdit, handleListingDelete, error }) => {
                       <b>{bookData.book.title}</b>
                     </p>
                     <p>{bookData.book.author}</p>
-                    <p>{bookData.book.page} pages</p>
-                    <p>{bookData.book.releaseYear}</p>
+                    <p>{bookData.book.page ? bookData.book.page + " pages" : ""}</p>
+                    <p>{bookData.book.releaseYear ? bookData.book.releaseYear : ""} </p>
                   </Col>
                 </Row>
                 <Row className={classNameSelectorRow(bookData.listing.availability)}>


### PR DESCRIPTION
The changes were implemented to ensure that the image URL, page count, and release year are no longer mandatory fields and appropriate data is displayed. Users can now add these details later on using the EditModal. (CR1)